### PR TITLE
security: harden runner container against RCE payload execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,14 +36,20 @@ WORKDIR /app
 ENV NODE_ENV production
 ENV NEXT_TELEMETRY_DISABLED 1
 
-# Install pnpm
-RUN npm install -g pnpm
+# Remove wget/curl/apk so a shell obtained inside the container can't
+# pull down payloads. Do this before copying app files so the layer is cached.
+RUN apk del --no-cache wget curl 2>/dev/null; \
+    rm -rf /sbin/apk /etc/apk /usr/bin/wget /usr/bin/curl
 
-# Copy only what's needed
-COPY --from=builder /app/.next ./.next
-COPY --from=builder /app/public ./public
-COPY --from=builder /app/package.json ./package.json
-COPY --from=deps /app/node_modules ./node_modules
+RUN addgroup --system --gid 1001 nodejs \
+ && adduser --system --uid 1001 nextjs
+
+# Copy only what's needed (standalone output — no pnpm/node_modules needed at runtime)
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+
+USER nextjs
 
 EXPOSE 3000
-CMD ["pnpm", "start"]
+CMD ["node", "server.js"]

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  output: "standalone",
   basePath: process.env.NEXT_PUBLIC_BASE_PATH,
   webpack: (config, { isServer }) => {
     if (!isServer) {


### PR DESCRIPTION
Production was hit with a wget-based malware dropper that succeeded because the alpine runner ran as root with wget/curl available and a writable/executable /tmp. Switch to Next standalone output, drop to a non-root user, and strip wget/curl/apk from the final image so a shell obtained via any future RCE has no way to fetch or run a payload.